### PR TITLE
fix(daserver/celestia): always init readClient

### DIFF
--- a/daserver/celestia.go
+++ b/daserver/celestia.go
@@ -247,30 +247,24 @@ func NewCelestiaDA(cfg *DAConfig) (*CelestiaDA, error) {
 				return nil, err
 			}
 
-			readClient, err = txclient.NewReadClient(context.Background(), readConfig)
-			if err != nil {
-				log.Error("error initializing read client", "err", err)
-				return nil, err
-			}
-
-			log.Info("Succesfully initialized write and read experimental txclient", "writeRpc", cfg.CoreURL, "readRpc", readConfig.BridgeDAAddr)
+			log.Info("Succesfully initialized write (experimental) txclient", "writeRpc", cfg.CoreURL)
 		} else {
 			daClient, err = node.NewClient(context.Background(), cfg.Rpc, cfg.AuthToken)
 			if err != nil {
 				log.Error("could not initialize node client for da rpc", "err", err)
 				return nil, err
 			}
+			log.Info("Succesfully initialized node da client", "writeRpc", cfg.Rpc)
 		}
 
-	} else {
-		var err error
-		readClient, err = txclient.NewReadClient(context.Background(), readConfig)
-		if err != nil {
-			log.Error("could not initialize txclient.ReadClient", "err", err)
-			return nil, err
-		}
-		log.Info("Succesfully initialized read only client", "rpc", cfg.Rpc)
 	}
+
+	readClient, err = txclient.NewReadClient(context.Background(), readConfig)
+	if err != nil {
+		log.Error("could not initialize txclient.ReadClient", "err", err)
+		return nil, err
+	}
+	log.Info("Succesfully initialized read client", "readRpc", readConfig.BridgeDAAddr)
 
 	da := &CelestiaDA{
 		Cfg:        cfg,


### PR DESCRIPTION
## Problem

If using the flags `celestia.with-writer=true` and `celestia.experimental-tx-client=false`, the `readClient` variable is not being initialised (nil pointer). That is, all read calls to celestia RPC would fail, example logs:

```bash
ERROR[09-11|16:01:21.744] RPC method daprovider_store crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 77 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/service.go:207 +0x85
panic({0x4064360?, 0x7cddf90?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
github.com/celestiaorg/nitro-das-celestia/daserver.(*CelestiaDA).Store(0xc001ca9aa0, {0x5228b18, 0xc0011c8af0}, {0xc001b610e0, 0x107, 0x107})
	/nitro-das-celestia/daserver/celestia.go:390 +0xe1e
github.com/celestiaorg/nitro-das-celestia/daserver/types.(*writerForCelestia).Store(0x10?, {0x5228b18?, 0xc0011c8af0?}, {0xc001b610e0?, 0x479df6?, 0x4211160?}, 0x442aa80?, 0x0)
	/nitro-das-celestia/daserver/types/writer.go:34 +0x33
github.com/celestiaorg/nitro-das-celestia/daserver.(*DaClientServer).Store(0xc001dc5bf0, {0x5228b18, 0xc0011c8af0}, {0xc001b610e0, 0x107, 0x107}, 0x68d6b8cb, 0x0)
	/nitro-das-celestia/daserver/rpc_server.go:229 +0x5a
reflect.Value.call({0xc000b45c70?, 0xc000b5b0a0?, 0xc001effba0?}, {0x48a2f16, 0x4}, {0xc001e3ad80, 0x5, 0xc001eb8a3b?})
	/usr/local/go/src/reflect/value.go:584 +0xca6
reflect.Value.Call({0xc000b45c70?, 0xc000b5b0a0?, 0x16?}, {0xc001e3ad80?, 0x20?, 0x47a219?})
	/usr/local/go/src/reflect/value.go:368 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc001dda0c0, {0x5228b18, 0xc0011c8af0}, {0xc001eb89e0, 0x10}, {0xc0011c8b40, 0x3, 0x4b75d3?})
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/service.go:213 +0x2ec
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc001e6ad80?, {0x5228b18?, 0xc0011c8af0?}, 0xc000539110, 0x3?, {0xc0011c8b40?, 0x47a219?, 0x30?})
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:568 +0x3c
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc0011c4820, 0xc001ea1aa0, 0xc000539110)
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:515 +0x229
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc0011c4820, 0xc001ea1aa0, 0xc000539110)
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:473 +0x22d
github.com/ethereum/go-ethereum/rpc.(*handler).handleNonBatchCall(0xc0011c4820, 0xc001ea1aa0, 0xc000539110)
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:299 +0x189
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1.1(0x5228b18?)
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:272 +0x25
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:390 +0xbb
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc in goroutine 38
	/go/pkg/mod/github.com/!ferret-san/go-ethereum@v1.13.4-0.20250619005312-0488d1d7bc61/rpc/handler.go:386 +0x76

WARN [09-11|16:01:21.744] Served daprovider_store                  conn=10.72.27.79:54992 reqid=229 duration=6.049487103s err="method handler crashed"
```

## Fix

Refactored the `if` condition in a way to always initialise the `readClient`.

## Testing

Seems to work!

```bash
INFO [09-11|17:54:07.205] Starting metrics server                  addr=http://0.0.0.0:6070/debug/metrics
INFO [09-11|17:54:07.211] Succesfully initialized node da client   writeRpc=http://celestia-rpc
INFO [09-11|17:54:07.211] Succesfully initialized read client      readRpc=http://celestia-rpc
INFO [09-11|17:54:21.657] Succesfully posted blob                  height=7,998,900 commitment=651ddab491e65e290537b27bf17c3c80be225070fe62eed16286e453b4e0e9d6
INFO [09-11|17:54:21.703] Posted blob to height and dataRoot       height=7,998,900 dataRoot=9274e54715603194b58ba233f74c5b36fad8c71ee6586e0e92e0e93447c33915
```