### PR TITLE
ci: fix docker buildx setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: docker/setup-buildx-action@4f1d3f8f48538f901ebd1b6dd4726c0f0de4f97f # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Overview

Copilot used the wrong hash in #48 